### PR TITLE
Improve array matching

### DIFF
--- a/src/main/java/net/pincette/json/streams/TestAsserters.java
+++ b/src/main/java/net/pincette/json/streams/TestAsserters.java
@@ -84,12 +84,11 @@ public final class TestAsserters {
         return false;
       }
 
-      for (int index = 0; index < expected.size(); index++) {
-        if (!matches(expected.get(index), actual.get(index))) {
-          return false;
-        }
-      }
-      return true;
+      return expected
+          .valueStream()
+          .allMatch(
+              expectedNode ->
+                  actual.valueStream().anyMatch(actualNode -> matches(expectedNode, actualNode)));
     }
 
     private static Optional<JsonNode> toJsonNode(JsonObject jsonObject) {


### PR DESCRIPTION
Enforce set‑like containment (every expected element must match some element in actual, in any order).